### PR TITLE
fix compact and option encoding regressions

### DIFF
--- a/types/Compact.go
+++ b/types/Compact.go
@@ -43,6 +43,9 @@ func (c *Compact) ProcessCompactBytes() {
 
 func (c *Compact) Process() {
 	c.ProcessCompactBytes()
+	if c.CompactLength > 4 {
+		c.requireCompleteCompactBytes()
+	}
 	if c.SubType == "" {
 		c.Value = c.CompactBytes
 		return
@@ -89,6 +92,19 @@ func (c *Compact) compactBytesForSubType() []byte {
 	compactBytes := make([]byte, byteLength)
 	copy(compactBytes, c.CompactBytes)
 	return compactBytes
+}
+
+func (c *Compact) compactValueLength() int {
+	if c.CompactLength > 4 {
+		return c.CompactLength - 1
+	}
+	return c.CompactLength
+}
+
+func (c *Compact) requireCompleteCompactBytes() {
+	if expected := c.compactValueLength(); len(c.CompactBytes) != expected {
+		panic(fmt.Sprintf("compact underflow: need %d bytes, got %d", expected, len(c.CompactBytes)))
+	}
 }
 
 func (c *Compact) TypeStructString() string {
@@ -157,9 +173,7 @@ func (c *CompactU32) Init(data scaleBytes.ScaleBytes, option *ScaleDecoderOption
 
 func (c *CompactU32) Process() {
 	c.ProcessCompactBytes()
-	if len(c.CompactBytes) != c.CompactLength {
-		panic(fmt.Sprintf("compact<u32> underflow: need %d bytes, got %d", c.CompactLength, len(c.CompactBytes)))
-	}
+	c.requireCompleteCompactBytes()
 	buf := &bytes.Buffer{}
 	var reader io.Reader
 	reader = buf

--- a/types/Option.go
+++ b/types/Option.go
@@ -25,26 +25,8 @@ func (o *Option) Encode(value interface{}) string {
 	if v, ok := value.(string); ok && v == "" {
 		return "00"
 	}
-	if value == nil {
+	if isNilInterface(value) {
 		return "00"
-	}
-	switch v := value.(type) {
-	case []byte:
-		if v == nil {
-			return "00"
-		}
-	case []interface{}:
-		if v == nil {
-			return "00"
-		}
-	case map[string]interface{}:
-		if v == nil {
-			return "00"
-		}
-	case error:
-		if v == nil {
-			return "00"
-		}
 	}
 	if o.SubType == "bool" {
 		if value.(bool) {

--- a/types/encode_helpers.go
+++ b/types/encode_helpers.go
@@ -1,42 +1,31 @@
 package types
 
-func toInterfaceSlice[T any](values []T) []interface{} {
-	out := make([]interface{}, len(values))
-	for i, v := range values {
-		out[i] = v
+import "reflect"
+
+func isNilInterface(value interface{}) bool {
+	if value == nil {
+		return true
 	}
-	return out
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 func asInterfaceSlice(value interface{}) ([]interface{}, bool) {
-	switch v := value.(type) {
-	case []interface{}:
-		return v, true
-	case []string:
-		return toInterfaceSlice(v), true
-	case []int:
-		return toInterfaceSlice(v), true
-	case []int8:
-		return toInterfaceSlice(v), true
-	case []int16:
-		return toInterfaceSlice(v), true
-	case []int32:
-		return toInterfaceSlice(v), true
-	case []int64:
-		return toInterfaceSlice(v), true
-	case []uint:
-		return toInterfaceSlice(v), true
-	case []uint16:
-		return toInterfaceSlice(v), true
-	case []uint32:
-		return toInterfaceSlice(v), true
-	case []uint64:
-		return toInterfaceSlice(v), true
-	case []byte:
-		return toInterfaceSlice(v), true
-	case []bool:
-		return toInterfaceSlice(v), true
-	default:
+	if value == nil {
 		return nil, false
 	}
+	v := reflect.ValueOf(value)
+	if v.Kind() != reflect.Slice {
+		return nil, false
+	}
+	out := make([]interface{}, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		out[i] = v.Index(i).Interface()
+	}
+	return out, true
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -107,6 +107,10 @@ func TestCompactBalance(t *testing.T) {
 func TestCompactU32EncodeLargeMode(t *testing.T) {
 	assert.Equal(t, "0300000040", Encode("Compact<u32>", uint32(1073741824)))
 	assert.Equal(t, "03ffffffff", Encode("Compact<u32>", uint32(4294967295)))
+
+	m := ScaleDecoder{}
+	m.Init(scaleBytes.ScaleBytes{Data: utiles.HexToBytes("0300000040")}, nil)
+	assert.Equal(t, 1073741824, m.ProcessAndUpdateData("Compact<u32>"))
 }
 
 func TestCompactUint64DoesNotOverflow(t *testing.T) {
@@ -123,6 +127,11 @@ func TestDecodePanicsOnTruncatedInput(t *testing.T) {
 	m.Init(scaleBytes.ScaleBytes{Data: utiles.HexToBytes("020001")}, nil)
 	assert.Panics(t, func() {
 		m.ProcessAndUpdateData("Compact<u32>")
+	})
+
+	m.Init(scaleBytes.ScaleBytes{Data: utiles.HexToBytes("13000064a7b3b6e")}, nil)
+	assert.Panics(t, func() {
+		m.ProcessAndUpdateData("Compact<Balance>")
 	})
 }
 
@@ -394,6 +403,13 @@ func TestFixedArrayEncodeInvalidInputMessage(t *testing.T) {
 func TestVecEncodeSliceTypes(t *testing.T) {
 	assert.Equal(t, "080100000002000000", Encode("Vec<u32>", []uint32{1, 2}))
 	assert.Equal(t, "080100000002000000", Encode("Vec<u32>", []int{1, 2}))
+	assert.Equal(t, "080100000002000000", Encode("Vec<u32>", []decimal.Decimal{decimal.NewFromInt(1), decimal.NewFromInt(2)}))
+}
+
+func TestOptionEncodeTypedNil(t *testing.T) {
+	var values []uint32
+	assert.Equal(t, "00", Encode("Option<Vec<u32>>", values))
+	assert.Equal(t, "0100", Encode("Option<Vec<u32>>", []uint32{}))
 }
 
 func TestU256(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix Compact<u32> big-integer mode decoding so valid large values do not panic as underflow.
- Detect truncated Compact<Balance> big-integer payloads instead of silently zero-padding them.
- Restore generic slice encoding support for Vec and FixedArray inputs.
- Restore typed nil Option encoding as None while preserving Some(empty) for non-nil empty slices.

## Root Cause

The v1.10.5 compact underflow check compared Compact<u32> value bytes against the total compact length in big-integer mode, where the first byte is a mode/length prefix and is not part of the value payload. The same release also narrowed generic slice and typed nil handling during encode refactors.

## Validation

- `source ~/.gvm/scripts/gvm && gvm use go1.25.3 >/dev/null && go test ./...`
